### PR TITLE
32X Support

### DIFF
--- a/RetriX.Shared/RetriX.Shared.csproj
+++ b/RetriX.Shared/RetriX.Shared.csproj
@@ -12,7 +12,7 @@
       
   <ItemGroup>
     <PackageReference Include="Acr.UserDialogs" Version="6.5.1" />
-    <PackageReference Include="LibRetriX" Version="0.1.27" />
+    <PackageReference Include="LibRetriX" Version="0.1.28" />
     <PackageReference Include="MvvmCross.Core" Version="5.7.0" />
     <PackageReference Include="Plugin.VersionTracking" Version="2.1.0" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />

--- a/RetriX.UWP/Package.appxmanifest
+++ b/RetriX.UWP/Package.appxmanifest
@@ -189,6 +189,16 @@
             </uap:SupportedFileTypes>
           </uap:FileTypeAssociation>
         </uap:Extension>
+        <uap:Extension Category="windows.fileTypeAssociation">
+          <uap:FileTypeAssociation Name="s32xroms">
+            <uap:DisplayName>ms-resource:S32XRomDescription\Text</uap:DisplayName>
+            <uap:Logo>Assets\FileIcon.png</uap:Logo>
+            <uap:InfoTip>ms-resource:S32XRomDescription\Text</uap:InfoTip>
+            <uap:SupportedFileTypes>
+              <uap:FileType>.32x</uap:FileType>
+            </uap:SupportedFileTypes>
+          </uap:FileTypeAssociation>
+        </uap:Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/RetriX.UWP/Package.appxmanifest
+++ b/RetriX.UWP/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="15612Aftnet.RetriX" Publisher="CN=Alberto Fustinoni, O=AlbertoFustinoni, L=Kawasaki, S=Kanagawa, C=JP" Version="2.0.4.0" />
+  <Identity Name="15612Aftnet.RetriX" Publisher="CN=Alberto Fustinoni, O=AlbertoFustinoni, L=Kawasaki, S=Kanagawa, C=JP" Version="2.1.0.0" />
   <mp:PhoneIdentity PhoneProductId="efc54b08-6566-4c74-810c-e9437145cdf4" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>ms-resource:AppName\Text</DisplayName>

--- a/RetriX.UWP/RetriX.UWP.csproj
+++ b/RetriX.UWP/RetriX.UWP.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17134.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/RetriX.UWP/RetriX.UWP.csproj
+++ b/RetriX.UWP/RetriX.UWP.csproj
@@ -240,43 +240,46 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="LibRetriX.BeetleNGP">
-      <Version>0.1.27</Version>
+      <Version>0.1.28</Version>
     </PackageReference>
     <PackageReference Include="LibRetriX.BeetlePCEFast">
-      <Version>0.1.27</Version>
+      <Version>0.1.28</Version>
     </PackageReference>
     <PackageReference Include="LibRetriX.BeetlePCFX">
-      <Version>0.1.27</Version>
+      <Version>0.1.28</Version>
     </PackageReference>
     <PackageReference Include="LibRetriX.BeetlePSX">
-      <Version>0.1.27</Version>
+      <Version>0.1.28</Version>
     </PackageReference>
     <PackageReference Include="LibRetriX.BeetleWSwan">
-      <Version>0.1.27</Version>
+      <Version>0.1.28</Version>
     </PackageReference>
     <PackageReference Include="LibRetriX.FBAlpha">
-      <Version>0.1.27</Version>
+      <Version>0.1.28</Version>
     </PackageReference>
     <PackageReference Include="LibRetriX.FCEUMM">
-      <Version>0.1.27</Version>
+      <Version>0.1.28</Version>
     </PackageReference>
     <PackageReference Include="LibRetriX.Gambatte">
-      <Version>0.1.27</Version>
+      <Version>0.1.28</Version>
     </PackageReference>
     <PackageReference Include="LibRetriX.GenesisPlusGX">
-      <Version>0.1.27</Version>
+      <Version>0.1.28</Version>
     </PackageReference>
     <PackageReference Include="LibRetriX.MelonDS">
-      <Version>0.1.27</Version>
+      <Version>0.1.28</Version>
     </PackageReference>
     <PackageReference Include="LibRetriX.Nestopia">
-      <Version>0.1.27</Version>
+      <Version>0.1.28</Version>
+    </PackageReference>
+    <PackageReference Include="LibRetriX.PicoDrive">
+      <Version>0.1.28</Version>
     </PackageReference>
     <PackageReference Include="LibRetriX.Snes9X">
-      <Version>0.1.27</Version>
+      <Version>0.1.28</Version>
     </PackageReference>
     <PackageReference Include="LibRetriX.VBAM">
-      <Version>0.1.27</Version>
+      <Version>0.1.28</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.1.5</Version>

--- a/RetriX.UWP/Services/GameSystemsProviderService.cs
+++ b/RetriX.UWP/Services/GameSystemsProviderService.cs
@@ -24,7 +24,7 @@ namespace RetriX.UWP.Services
             yield return GameSystemViewModel.MakeGameGear(LibRetriX.GenesisPlusGX.Core.Instance, fileSystem);
             yield return GameSystemViewModel.MakeMegaDrive(LibRetriX.GenesisPlusGX.Core.Instance, fileSystem);
             yield return GameSystemViewModel.MakeMegaCD(LibRetriX.GenesisPlusGX.Core.Instance, fileSystem);
-            //yield return GameSystemViewModel.Make32X(LibRetriX.PicoDrive.Core.Instance, fileSystem);
+            yield return GameSystemViewModel.Make32X(LibRetriX.PicoDrive.Core.Instance, fileSystem);
             //yield return GameSystemViewModel.MakeSaturn(LibRetriX.BeetleSaturn.Core.Instance, fileSystem);
             yield return GameSystemViewModel.MakePlayStation(LibRetriX.BeetlePSX.Core.Instance, fileSystem);
             yield return GameSystemViewModel.MakePCEngine(LibRetriX.BeetlePCEFast.Core.Instance, fileSystem);

--- a/RetriX.UWP/Strings/en-US/Resources.resw
+++ b/RetriX.UWP/Strings/en-US/Resources.resw
@@ -240,4 +240,7 @@
   <data name="ZipRomDescription.Text" xml:space="preserve">
     <value>Zip compressed Rom</value>
   </data>
+  <data name="S32XRomDescription.Text" xml:space="preserve">
+    <value>SEGA 32X Rom</value>
+  </data>
 </root>


### PR DESCRIPTION
- Added 32X support vis PicoDrive
- Bumped min Windows 10 version to 16299 - Fall Creators Update.

Reason for increasing minimum Windows Version is that `span<t>` doesn't seem to work properly:; compilation fails on Creator Update in release mode. Trying to get this looked fixed and bring baseline to CU.